### PR TITLE
Fix some documentation links

### DIFF
--- a/scribblings/main.scrbl
+++ b/scribblings/main.scrbl
@@ -1,10 +1,13 @@
 #lang scribble/manual
 
+@(require (for-label ocular-patdown/update
+                     racket/match))
+
 @title{Ocular Patdown}
 @author[@author+email["Mike Delmonaco" "mdelmonacochs@gmail.com"]]
 
 This is a (currently experimental) library for @tech{optic}s. Optics are useful for performing deep immutable updates and accesses within structures.
-This library also provides the @racket[update] form, which is like match, but can be used for immutable updates as well.
+This library also provides the @racket[update] form, which is like @racket[match], but can be used for immutable updates as well.
 The @racket[update] form does not require knowledge of optics to use.
 
 For those unfamiliar with lenses, read the @seclink["optics-guide"]{Optics Guide}.


### PR DESCRIPTION
This links the `update` and `match` forms to their respective definitions in the documentation. I think. Haven't rendered it myself to double-check.